### PR TITLE
fix: Display dynamic copyright year in footer

### DIFF
--- a/src/components/footer/__tests__/footer.test.tsx
+++ b/src/components/footer/__tests__/footer.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 
 import Footer from "..";
 
-const FIXED_DATE = new Date("2026-01-01T00:00:00.000Z");
+const FIXED_DATE = new Date("2026-01-01T12:00:00.000Z");
 const EXPECTED_YEAR = FIXED_DATE.getFullYear();
 
 // Test suite for Footer component

--- a/src/components/footer/__tests__/footer.test.tsx
+++ b/src/components/footer/__tests__/footer.test.tsx
@@ -1,15 +1,22 @@
 import "@testing-library/jest-dom";
 
 import { render, screen } from "@testing-library/react";
-import React from "react";
 
 import Footer from "..";
 
+const FIXED_DATE = new Date("2026-01-01T00:00:00.000Z");
+const EXPECTED_YEAR = FIXED_DATE.getFullYear();
+
 // Test suite for Footer component
 describe("Footer Component", () => {
-    // Render Footer component before each test
     beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(FIXED_DATE);
         render(<Footer />);
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
     });
 
     // Test if Footer component renders correctly
@@ -22,10 +29,9 @@ describe("Footer Component", () => {
         const changelogLink = screen.getByText("업데이트 내역");
         expect(changelogLink).toBeInTheDocument();
 
-        // Check if copyright text exists
-        const currentYear = new Date().getFullYear();
+        // Check if copyright text matches the fixed system date
         const copyrightText = screen.getByText(
-            `Copyright © ${currentYear} Erinn.me. All rights reserved.`
+            `Copyright © ${EXPECTED_YEAR} Erinn.me. All rights reserved.`
         );
         expect(copyrightText).toBeInTheDocument();
     });

--- a/src/components/footer/__tests__/footer.test.tsx
+++ b/src/components/footer/__tests__/footer.test.tsx
@@ -23,7 +23,10 @@ describe("Footer Component", () => {
         expect(changelogLink).toBeInTheDocument();
 
         // Check if copyright text exists
-        const copyrightText = screen.getByText(/Copyright © 2024 Erinn.me/);
+        const currentYear = new Date().getFullYear();
+        const copyrightText = screen.getByText(
+            `Copyright © ${currentYear} Erinn.me. All rights reserved.`
+        );
         expect(copyrightText).toBeInTheDocument();
     });
 

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import React from "react";
 
 function Footer() {
+    const currentYear = new Date().getFullYear();
+
     return (
         <footer className="footer footer-center p-2 py-4 bg-base-200 text-base-content">
             <div className="flex flex-row">
@@ -13,7 +15,7 @@ function Footer() {
                 </Link>
             </div>
             <div>
-                <p>Copyright © 2024 Erinn.me. All rights reserved.</p>
+                <p>Copyright © {currentYear} Erinn.me. All rights reserved.</p>
             </div>
         </footer>
     );


### PR DESCRIPTION
### :wave: Background

The footer displayed a hardcoded copyright year (`2024`), which became outdated and required manual updates each year.

### :link: Related Issues

-

### :gear: Description

- Replace the hardcoded `2024` copyright year in `Footer` with `new Date().getFullYear()` so the year updates automatically
- Update footer unit tests to use Jest fake timers with a fixed midday UTC instant (`2026-01-01T12:00:00.000Z`) so the expected year is deterministic across timezones
- Restore real timers after each test to avoid leaking fake timer state

### :rotating_light: To Reviewers

Please verify that the copyright year renders correctly in the footer and that the fake-timer test setup does not affect other test suites.

Made with [Cursor](https://cursor.com)